### PR TITLE
Fix const redefine warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 dist: trusty
+sudo: required
 
 language: c
 compiler:
   - gcc
   - clang
 env:
-  - MRUBY_VERSION=1.2.0
+  - MRUBY_VERSION=1.3.0
+  - MRUBY_VERSION=1.4.1
   - MRUBY_VERSION=master
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
       - bison
       - git
       - gperf
-      - aclocal
+      # - aclocal
       - automake
       - autoconf
       - autotools-dev

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,5 +1,7 @@
 module AppArmor
-  APPARMOR_VERSION = "2.10.95"
+  unless AppArmor.const_defined? :APPARMOR_VERSION
+    APPARMOR_VERSION = "2.10.95"
+  end
 end
 
 require 'fileutils'


### PR DESCRIPTION
In some case rake process shows:

```
/path/to/haconiwa/mruby/build/mrbgems/mruby-apparmor/mrbgem.rake:2: warning: already initialized constant AppArmor::APPARMOR_VERSION
/path/to/haconiwa/mruby/build/mrbgems/mruby-apparmor/mrbgem.rake:2: warning: previous definition of APPARMOR_VERSION was here
```